### PR TITLE
Add critical issue count and payload normalization

### DIFF
--- a/backend_portal/fleet_manager/portal/serializers.py
+++ b/backend_portal/fleet_manager/portal/serializers.py
@@ -376,7 +376,9 @@ class InspectionListSerializer(serializers.ModelSerializer):
     vehicle = VehicleSerializer(read_only=True)
     inspector = InspectorProfileSerializer(read_only=True)
     customer = CustomerSerializer(read_only=True)
+    customer_report = CustomerReportSerializer(read_only=True)
     status_display = serializers.CharField(source="get_status_display", read_only=True)
+    critical_issue_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Inspection
@@ -388,10 +390,19 @@ class InspectionListSerializer(serializers.ModelSerializer):
             "inspector",
             "status",
             "status_display",
+            "critical_issue_count",
+            "customer_report",
             "created_at",
             "updated_at",
         ]
         read_only_fields = fields
+
+    def get_critical_issue_count(self, obj: Inspection) -> int:
+        responses = getattr(obj, "item_responses", None)
+        if responses is None:
+            return 0
+        iterable = responses.all() if hasattr(responses, "all") else responses
+        return sum(1 for response in iterable if response.result == InspectionItemResponse.RESULT_FAIL)
 
 
 class InspectionCategorySerializer(serializers.ModelSerializer):

--- a/backend_portal/fleet_manager/portal/views.py
+++ b/backend_portal/fleet_manager/portal/views.py
@@ -279,6 +279,7 @@ class InspectionViewSet(viewsets.ModelViewSet):
         "inspector__profile",
         "inspector__profile__user",
         "customer",
+        "customer_report",
     ).prefetch_related(
         Prefetch(
             "item_responses",

--- a/backend_portal/fleet_manager/portal/views.py
+++ b/backend_portal/fleet_manager/portal/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any, List, Tuple
 
 from django.db.models import Prefetch
 from django.http import QueryDict

--- a/backend_portal/fleet_manager/portal/views.py
+++ b/backend_portal/fleet_manager/portal/views.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
+
 from django.db.models import Prefetch
-from rest_framework import mixins, viewsets
+from django.http import QueryDict
+from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken


### PR DESCRIPTION
## Changes Made

### Serializer Updates
- Added `customer_report` field to `InspectionListSerializer` with read-only access
- Added `critical_issue_count` field as a `SerializerMethodField` to calculate failed inspection items
- Updated Meta fields list to include both new fields
- Implemented `get_critical_issue_count()` method that counts inspection item responses with `RESULT_FAIL` status

### ViewSet Enhancements
- Added `customer_report` to the `select_related` queryset optimization in `InspectionViewSet`
- Implemented payload normalization functionality with helper functions:
  - `_extract_data_pairs()` - extracts key-value pairs from QueryDict or dict
  - `_assign_path()` - assigns values to nested dictionary/list structures
  - `_assign_nested_item()` - handles nested item response data parsing
  - `_normalize_inspection_payload()` - main function to normalize inspection data including JSON parsing
- Added `_prepare_payload()` method to process request data before serialization
- Overrode `create()`, `update()`, and `partial_update()` methods to use payload normalization

### Import Additions
- Added `json`, `typing.Any`, `typing.List`, `typing.Tuple` imports
- Added `QueryDict` from `django.http` and `status` from `rest_framework`

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/851f5fd69994454baefaf8b5d3db9f85/nova-den)

👀 [Preview Link](https://851f5fd69994454baefaf8b5d3db9f85-nova-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>851f5fd69994454baefaf8b5d3db9f85</projectId>-->
<!--<branchName>nova-den</branchName>-->